### PR TITLE
Make PterodactylLib pick up default port from Environment

### DIFF
--- a/PterodactylExample/PterodactylExample.xcodeproj/project.pbxproj
+++ b/PterodactylExample/PterodactylExample.xcodeproj/project.pbxproj
@@ -142,7 +142,6 @@
 				C9D79BC82421B7B9009F111A /* Sources */,
 				C9D79BC92421B7B9009F111A /* Frameworks */,
 				C9D79BCA2421B7B9009F111A /* Resources */,
-				C9258B8E24280BE8003D026E /* Run Server Run Script */,
 			);
 			buildRules = (
 			);
@@ -212,27 +211,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		C9258B8E24280BE8003D026E /* Run Server Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run Server Run Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nopen -a \"${SOURCE_ROOT}/../PterodactylLib/Built_Product/PterodactylServer.app\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C9D79BB22421B7B9009F111A /* Sources */ = {

--- a/PterodactylExample/PterodactylExample.xcodeproj/xcshareddata/xcschemes/PterodactylExample.xcscheme
+++ b/PterodactylExample/PterodactylExample.xcodeproj/xcshareddata/xcschemes/PterodactylExample.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -41,6 +41,24 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "&quot;${PROJECT_DIR}/../run_server.sh&quot; -port ${PTERODACTYL_PORT:=8081}&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "C9D79BB52421B7B9009F111A"
+                     BuildableName = "PterodactylExample.app"
+                     BlueprintName = "PterodactylExample"
+                     ReferencedContainer = "container:PterodactylExample.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
@@ -83,6 +101,13 @@
             ReferencedContainer = "container:PterodactylExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PTERODACTYL_PORT"
+            value = "${PTERODACTYL_PORT}"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/PterodactylLib/Classes/Pterodactyl.swift
+++ b/PterodactylLib/Classes/Pterodactyl.swift
@@ -14,7 +14,9 @@ public class Pterodactyl {
     let host: String
     let port: in_port_t
 
-    public init(targetAppBundleId: String, host: String = "localhost", port: in_port_t = 8081) {
+    public static let defaultPort = defaultPortFromEnvironment()
+
+    public init(targetAppBundleId: String, host: String = "localhost", port: in_port_t = Pterodactyl.defaultPort) {
         self.targetAppBundleId = targetAppBundleId
         self.host = host
         self.port = port
@@ -127,5 +129,14 @@ public class Pterodactyl {
         task.resume()
         group.wait()
     }
-    
+
+    private static func defaultPortFromEnvironment() -> in_port_t {
+        let defaultPort: in_port_t = 8081
+        guard let portString = ProcessInfo.processInfo.environment["PTERODACTYL_PORT"] else {
+            return defaultPort
+        }
+        let port = in_port_t(portString) ?? defaultPort
+        return port
+    }
+
 }


### PR DESCRIPTION
This is easier and less error prone than remembering to set the port on every initialisation. The current default port (8081) conflicts with React Native’s live server.